### PR TITLE
added new internal authenticate instruction code

### DIFF
--- a/pcsc-sharp/Iso7816/Enums/InstructionCode.cs
+++ b/pcsc-sharp/Iso7816/Enums/InstructionCode.cs
@@ -24,7 +24,10 @@ namespace PCSC.Iso7816
         GetChallenge = 0x84,
         /// <summary>Internal authenticate</summary>
         [Description("INTERNAL AUTHENTICATE")]
-        InternalAuthenticate = 0x88,
+        InternalAuthenticate = 0x86,
+        /// <summary>Internal authenticate (obsolete)</summary>
+        [Description("INTERNAL AUTHENTICATE")]
+        InternalAuthenticateObsolete = 0x88,
         /// <summary>Select file</summary>
         [Description("SELECT FILE")]
         SelectFile = 0xA4,


### PR DESCRIPTION
Added new (?) instruction according to page 13 in [ACS-API], because I need the 0x86-instruction for my project. Feel free to give them better names.

[ACS-API] http://www.acs.com.hk/drivers/eng/API-ACR122U-2.02.pdf
