### PR TITLE
Dispose in the event handler bug fix

### DIFF
--- a/pcsc-sharp/SCardMonitor.cs
+++ b/pcsc-sharp/SCardMonitor.cs
@@ -479,7 +479,7 @@ namespace PCSC
 
                             // Card removed
                             if (newState.CardIsAbsent() && previousState.CardIsPresent()) {
-                                new Thread(() => OnCardRemoved(atr, readerName, newState));
+                                new Thread(() => OnCardRemoved(atr, readerName, newState)).Start();
                             }
 
                             _previousStates[i] = newState;

--- a/pcsc-sharp/SCardMonitor.cs
+++ b/pcsc-sharp/SCardMonitor.cs
@@ -469,17 +469,17 @@ namespace PCSC
 
                             // Status change
                             if (previousState != newState) {
-                                OnStatusChanged(atr, readerName, previousState, newState);
+                               new Thread(() => OnStatusChanged(atr, readerName, previousState, newState)).Start();
                             }
 
                             // Card inserted
                             if (newState.CardIsPresent() && previousState.CardIsAbsent()) {
-                                OnCardInserted(atr, readerName, newState);
+                                new Thread(() => OnCardInserted(atr, readerName, newState)).Start();
                             }
 
                             // Card removed
                             if (newState.CardIsAbsent() && previousState.CardIsPresent()) {
-                                OnCardRemoved(atr, readerName, newState);
+                                new Thread(() => OnCardRemoved(atr, readerName, newState));
                             }
 
                             _previousStates[i] = newState;


### PR DESCRIPTION
I decided to run every event handler in the new thread and now it's possible to dispose the monitor inside the handlers.