### PR TITLE
Fix GET RESPONSE ADPU SW2

### DIFF
--- a/pcsc-sharp/Iso7816/IsoReader.cs
+++ b/pcsc-sharp/Iso7816/IsoReader.cs
@@ -314,8 +314,8 @@ namespace PCSC.Iso7816
                  * Le = min(Le,SW2) 
                  */
                 var le = (commandApdu.Le < responseApdu.SW2)
-                    ? commandApdu.Le
-                    : responseApdu.SW2;
+                    ? responseApdu.SW2
+                    : commandApdu.Le;
 
                 do {
                     // add the last ResponseAPDU to the Response object


### PR DESCRIPTION
Hello,

Since I am using pcsc-sharp, I have to modify this otherwise I get 6C00 "Incorrect P3 length.".

Maybe I did something wrong ? Even this quick fix can be incorrect.

Could you please share your point of view ? Thanks !