### PR TITLE
Fix setting the CardChangeEventCnt

### DIFF
--- a/pcsc-sharp.Test/SCardReaderStateTest.cs
+++ b/pcsc-sharp.Test/SCardReaderStateTest.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using System;
+using PCSC;
+
+namespace PcSc
+{
+	[TestFixture ()]
+	public class SCardReaderStateTest
+	{
+		[Test ()]
+		public void CardChangeEventCntSetEventStateValueTest ()
+		{
+			SCardReaderState state = new SCardReaderState ();
+			state.EventStateValue = new IntPtr(0);
+			Assert.AreEqual (0, state.CardChangeEventCnt);
+			//set the counter (upper 2 bytes of the event state) to 1
+			state.EventStateValue = new IntPtr (0x00010000);
+			Assert.AreEqual (1, state.CardChangeEventCnt);
+			//Set the maximum value
+			state.EventStateValue = new IntPtr (0xFFFF0000);
+			Assert.AreEqual (65535, state.CardChangeEventCnt);
+		}
+
+		[Test ()]
+		public void CardChangeEventCntSetTest ()
+		{
+			SCardReaderState state = new SCardReaderState ();
+			state.EventState = SCRState.Empty;
+			state.CardChangeEventCnt = 0;
+			Assert.AreEqual (0, state.CardChangeEventCnt);
+			Assert.AreEqual ((uint)SCRState.Empty, (uint)state.EventStateValue.ToInt32());
+			Assert.AreEqual (SCRState.Empty, state.EventState, "EventState should not change by setting the Counter");
+			//set the counter to 1
+			state.CardChangeEventCnt = 1;
+			Assert.AreEqual (1, state.CardChangeEventCnt);
+			Assert.AreEqual (0x00010010, (uint)state.EventStateValue.ToInt32());
+			Assert.AreEqual (SCRState.Empty, state.EventState, "EventState should not change by setting the Counter");
+			//Set the maximum value
+			state.CardChangeEventCnt = 65535;
+			Assert.AreEqual (65535, state.CardChangeEventCnt);
+			Assert.AreEqual (0xFFFF0010, (uint)state.EventStateValue.ToInt32());
+			//try to set a value that is too high
+			Assert.Throws(Is.InstanceOf<ArgumentException>(), () => (state.CardChangeEventCnt = 65536));
+			//try to set a negative value
+			Assert.Throws(Is.InstanceOf<ArgumentException>(), () => (state.CardChangeEventCnt = -1));
+		}
+	}
+}
+

--- a/pcsc-sharp.sln
+++ b/pcsc-sharp.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pcsc-sharp", "pcsc-sharp\pcsc-sharp.csproj", "{459E0FB4-AF42-4123-9923-7EA68CA01B09}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pcsc-sharp.Test", "pcsc-sharp.Test\pcsc-sharp.Test.csproj", "{9945C93A-8730-4EEB-86CF-79DFC8DD2190}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,6 +15,10 @@ Global
 		{459E0FB4-AF42-4123-9923-7EA68CA01B09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{459E0FB4-AF42-4123-9923-7EA68CA01B09}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{459E0FB4-AF42-4123-9923-7EA68CA01B09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9945C93A-8730-4EEB-86CF-79DFC8DD2190}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9945C93A-8730-4EEB-86CF-79DFC8DD2190}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9945C93A-8730-4EEB-86CF-79DFC8DD2190}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9945C93A-8730-4EEB-86CF-79DFC8DD2190}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pcsc-sharp/SCardReaderState.cs
+++ b/pcsc-sharp/SCardReaderState.cs
@@ -193,10 +193,10 @@ namespace PCSC
                 var es = (long) EventState; // save EventState
                 if (Platform.IsWindows) {
                     _winscardRstate.dwEventState = unchecked((Int32)
-                        (((value & CHCOUNT_RANGE) << 16) | es));
+                        (((value & EVENTSTATE_RANGE) << 16) | es));
                 } else {
                     _pcscliteRstate.dwEventState = unchecked((IntPtr)
-                        (((value & CHCOUNT_RANGE) << 16) | es));
+                        (((value & EVENTSTATE_RANGE) << 16) | es));
                 }
             }
         }

--- a/pcsc-sharp/SCardReaderState.cs
+++ b/pcsc-sharp/SCardReaderState.cs
@@ -190,6 +190,8 @@ namespace PCSC
                     : (int) ((((long) _pcscliteRstate.dwEventState) & CHCOUNT_RANGE) >> 16);
             }
             set {
+				if ((value < 0) || (value > 0xFFFF))
+					throw new ArgumentOutOfRangeException ("value");
                 var es = (long) EventState; // save EventState
                 if (Platform.IsWindows) {
                     _winscardRstate.dwEventState = unchecked((Int32)

--- a/pcsc-sharp/SCardReaderState.cs
+++ b/pcsc-sharp/SCardReaderState.cs
@@ -193,12 +193,13 @@ namespace PCSC
 				if ((value < 0) || (value > 0xFFFF))
 					throw new ArgumentOutOfRangeException ("value");
                 var es = (long) EventState; // save EventState
+				//The upper 2 bytes of the EventStateValue hold the CardChangeEventCounter, the lower 2 bytes the EventState
                 if (Platform.IsWindows) {
                     _winscardRstate.dwEventState = unchecked((Int32)
-                        (((value & EVENTSTATE_RANGE) << 16) | es));
+						(((value << 16) & CHCOUNT_RANGE) | es));
                 } else {
                     _pcscliteRstate.dwEventState = unchecked((IntPtr)
-                        (((value & EVENTSTATE_RANGE) << 16) | es));
+						(((value << 16) & CHCOUNT_RANGE) | es));
                 }
             }
         }

--- a/pcsc-sharp/pcsc-sharp.csproj
+++ b/pcsc-sharp/pcsc-sharp.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{459E0FB4-AF42-4123-9923-7EA68CA01B09}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -42,8 +40,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <OutputType>Library</OutputType>
-    <RootNamespace>PCSC</RootNamespace>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <DocumentationFile>bin\Debug\pcsc-sharp.xml</DocumentationFile>
   </PropertyGroup>
@@ -54,9 +50,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <OutputType>Library</OutputType>
     <DebugSymbols>true</DebugSymbols>
-    <RootNamespace>PCSC</RootNamespace>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <DocumentationFile>bin\Release\pcsc-sharp.xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
When setting the CardChange counter (stored in the upper bytes of the EventState) you have to take the lower bytes of the value passed before shifting them.
The way it was before (using the upper bytes of value before shifting), it always reulted in a counter of 0.