### PR TITLE
Add support for Windows CE devices

### DIFF
--- a/pcsc-sharp/Interop/Platform.cs
+++ b/pcsc-sharp/Interop/Platform.cs
@@ -23,7 +23,7 @@ namespace PCSC.Interop
         static Platform() {
             var platform = Environment.OSVersion.Platform.ToString();
 
-            if (platform.Contains("Win32") || platform.Contains("Win64")) {
+            if (platform.Contains("Win32") || platform.Contains("Win64") || platform.Contains("WinCE")) {
                 IsWindows = true;
                 Lib = new WinSCardAPI {
                     TextEncoding = new UnicodeEncoding()


### PR DESCRIPTION
Full implementation of winscard.dll is also available on WIndows CE, so I added support for it. I also tested it and works as expected.