### PR TITLE
VS2017, Test Fix, References

### DIFF
--- a/Examples/ListReaderEvents/ListReaderEvents.csproj
+++ b/Examples/ListReaderEvents/ListReaderEvents.csproj
@@ -36,13 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Examples/ListReaderEventsNative/ListReaderEventsNative.csproj
+++ b/Examples/ListReaderEventsNative/ListReaderEventsNative.csproj
@@ -36,13 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/Tests/pcsc-sharp-rx.Tests/pcsc-sharp-rx.Tests.csproj
+++ b/Tests/pcsc-sharp-rx.Tests/pcsc-sharp-rx.Tests.csproj
@@ -67,6 +67,9 @@
       <Name>pcsc-sharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/pcsc-sharp.Tests/SCardReaderStateTest.cs
+++ b/Tests/pcsc-sharp.Tests/SCardReaderStateTest.cs
@@ -23,10 +23,22 @@ namespace PCSC.Tests
                 .Be(1);
 
             //Set the maximum value
-            state.EventStateValue = unchecked(new IntPtr(0xFFFF0000));
-            state.CardChangeEventCnt
-                .Should()
-                .Be(65535);
+            //The maximum value depends on the architecture.
+            //If the process is running 32-bit, IntPtr(long) throws an exception.
+            if (IntPtr.Size == sizeof(Int64))
+            {
+                state.EventStateValue = unchecked(new IntPtr(0xFFFF0000));
+                state.CardChangeEventCnt
+                    .Should()
+                    .Be(0xFFFF);
+            }
+            else
+            {
+                state.EventStateValue = unchecked(new IntPtr(0x7FFF0000));
+                state.CardChangeEventCnt
+                    .Should()
+                    .Be(0x7FFF);
+            }
         }
 
         [Test]

--- a/Tests/pcsc-sharp.Tests/pcsc-sharp.Tests.csproj
+++ b/Tests/pcsc-sharp.Tests/pcsc-sharp.Tests.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -55,6 +56,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="paket.references" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/pcsc-sharp.sln
+++ b/pcsc-sharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pcsc-sharp", "pcsc-sharp\pcsc-sharp.csproj", "{459E0FB4-AF42-4123-9923-7EA68CA01B09}"
 EndProject


### PR DESCRIPTION
Fix test that fails when running 32-bit due to pointer overflow.
Upgrade solution file to VS2017.
Remove some unused project references.