### PR TITLE
Make Iso7816.Response constructor and Add methods public

### DIFF
--- a/pcsc-sharp/Iso7816/Response.cs
+++ b/pcsc-sharp/Iso7816/Response.cs
@@ -45,17 +45,17 @@ namespace PCSC.Iso7816
         }
 
         /// <summary>Initializes a new instance of the <see cref="Response" /> class.</summary>
-        protected internal Response() {}
+        public Response() {}
 
         /// <summary>Adds the specified response APDU.</summary>
         /// <param name="responseApdu">The response APDU.</param>
-        protected internal void Add(ResponseApdu responseApdu) {
+        public void Add(ResponseApdu responseApdu) {
             _lstResponseApdu.Add(responseApdu);
         }
 
         /// <summary>Adds the specified PCI.</summary>
         /// <param name="receivePci">The PCI.</param>
-        protected internal void Add(SCardPCI receivePci) {
+        public void Add(SCardPCI receivePci) {
             _lstReceivePci.Add(receivePci);
         }
 


### PR DESCRIPTION
I am implementing IIsoReader in my own class in another project, and the IIsoReader.Transmit method returns a Response object. However, the constructor and Add methods on Response are protected internal, which prevents me from actually implementing the Transmit method. This pull request makes those methods public. 

There are other design options that would solve this problem, for instance extracting the interface from Reader into a new interface IReader and changing IIsoReader.Transmit to return an IReader instead of the concrete Reader class. I'm happy to implement it that way if the maintainer(s) prefers that design, but I thought I'd see how the simple change was received before going  the more intrusive route.

In case you're curious, the reason I'm implementing IIsoReader is to create an implementation that communicates over the U2F HID protocol, so that I can talk to U2F tokens using the same API whether they are in U2F mode or CCID mode.
