### PR TITLE
Add .NET Standard 2.0 project/package and the needed adaptions to support it

### DIFF
--- a/pcsc-sharp.sln
+++ b/pcsc-sharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pcsc-sharp", "pcsc-sharp\pcsc-sharp.csproj", "{459E0FB4-AF42-4123-9923-7EA68CA01B09}"
 EndProject
@@ -54,6 +54,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pcsc-standard", "pcsc-sharp\pcsc-standard.csproj", "{6EA7D7C5-10D2-4158-BA6F-7F85D7CBD653}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -129,6 +131,10 @@ Global
 		{D611B7BA-35A2-4B06-AA77-25762B1DBAFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D611B7BA-35A2-4B06-AA77-25762B1DBAFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D611B7BA-35A2-4B06-AA77-25762B1DBAFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EA7D7C5-10D2-4158-BA6F-7F85D7CBD653}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EA7D7C5-10D2-4158-BA6F-7F85D7CBD653}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EA7D7C5-10D2-4158-BA6F-7F85D7CBD653}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EA7D7C5-10D2-4158-BA6F-7F85D7CBD653}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -151,5 +157,8 @@ Global
 		{CBCFD4A6-694B-4089-8B0F-2C158214BE02} = {D3253E47-228E-4C58-930E-A26849AEC371}
 		{F39FC685-9FB2-490D-9DDD-AE64379D7545} = {D3253E47-228E-4C58-930E-A26849AEC371}
 		{D611B7BA-35A2-4B06-AA77-25762B1DBAFF} = {5CC8F301-1496-4255-9AE2-1B734C9E9571}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4ED2E311-686A-4CB1-8271-68EBBD5FDB8E}
 	EndGlobalSection
 EndGlobal

--- a/pcsc-sharp/Interop/Windows/SCARD_IO_REQUEST.cs
+++ b/pcsc-sharp/Interop/Windows/SCARD_IO_REQUEST.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace PCSC.Interop.Windows
 {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal class SCARD_IO_REQUEST
     {
         internal int dwProtocol;

--- a/pcsc-sharp/Interop/Windows/SCARD_READERSTATE.cs
+++ b/pcsc-sharp/Interop/Windows/SCARD_READERSTATE.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace PCSC.Interop.Windows
 {
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct SCARD_READERSTATE
     {
         internal IntPtr pszReader;
@@ -11,8 +11,8 @@ namespace PCSC.Interop.Windows
         internal int dwCurrentState;
         internal int dwEventState;
         internal int cbAtr;
-        
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = WinSCardAPI.MAX_ATR_SIZE, ArraySubType = UnmanagedType.U1)] 
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = WinSCardAPI.MAX_ATR_SIZE, ArraySubType = UnmanagedType.U1)]
         internal byte[] rgbAtr;
     }
 }

--- a/pcsc-sharp/Interop/Windows/WinSCardAPI.cs
+++ b/pcsc-sharp/Interop/Windows/WinSCardAPI.cs
@@ -6,7 +6,7 @@ using PCSC.Interop.Windows.Extensions;
 namespace PCSC.Interop.Windows
 {
     /// <summary>
-    /// PC/SC API for Microsoft Win32/Win64 (x86/x64/IA64) 
+    /// PC/SC API for Microsoft Win32/Win64 (x86/x64/IA64)
     /// </summary>
     internal sealed class WinSCardAPI : ISCardAPI
     {
@@ -16,7 +16,7 @@ namespace PCSC.Interop.Windows
         private const int CHARSIZE = sizeof(char);
 
         private readonly Encoding _textEncoding = Encoding.Unicode;
-        
+
         public const int MAX_ATR_SIZE = 0x24;
 
         private IntPtr _dllHandle = IntPtr.Zero;
@@ -27,7 +27,7 @@ namespace PCSC.Interop.Windows
 
         public int CharSize => CHARSIZE;
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardEstablishContext(
             [In] int dwScope,
             [In] IntPtr pvReserved1,
@@ -46,7 +46,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardReleaseContext(
             [In] IntPtr hContext);
 
@@ -54,7 +54,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardReleaseContext(hContext));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardIsValidContext(
             [In] IntPtr hContext);
 
@@ -62,7 +62,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardIsValidContext(hContext));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardListReaders(
             [In] IntPtr hContext,
             [In] byte[] mszGroups,
@@ -105,7 +105,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardListReaderGroups(
             [In] IntPtr hContext,
             [Out] byte[] mszGroups,
@@ -142,7 +142,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardConnect(
             [In] IntPtr hContext,
             [In] byte[] szReader,
@@ -166,7 +166,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(result);
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardReconnect(
             [In] IntPtr hCard,
             [In] int dwShareMode,
@@ -186,7 +186,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(result);
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardDisconnect(
             [In] IntPtr hCard,
             [In] int dwDisposition);
@@ -195,7 +195,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardDisconnect(hCard, (int) dwDisposition));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardBeginTransaction(
             [In] IntPtr hCard);
 
@@ -203,7 +203,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardBeginTransaction(hCard));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardEndTransaction(
             [In] IntPtr hCard,
             [In] int dwDisposition);
@@ -212,7 +212,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardEndTransaction(hCard, (int) dwDisposition));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardTransmit(
             [In] IntPtr hCard,
             [In] IntPtr pioSendPci,
@@ -283,7 +283,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardControl(
             [In] IntPtr hCard,
             [In] int dwControlCode,
@@ -306,7 +306,7 @@ namespace PCSC.Interop.Windows
 
             var rc = SCardHelper.ToSCardError(SCardControl(
                 hCard,
-                unchecked((int)dwControlCode.ToInt64()), // On a 64-bit platform IntPtr.ToInt32() will throw an OverflowException 
+                unchecked((int)dwControlCode.ToInt64()), // On a 64-bit platform IntPtr.ToInt32() will throw an OverflowException
                 pbSendBuffer,
                 sendbuflen,
                 pbRecvBuffer,
@@ -318,7 +318,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardStatus(
             [In] IntPtr hCard,
             [Out] byte[] szReaderName,
@@ -346,7 +346,7 @@ namespace PCSC.Interop.Windows
 
             if (rc == SCardError.InsufficientBuffer || (MAX_READER_NAME < readerNameSize) || (pbAtr.Length < atrlen)) {
                 // second try
-               
+
                 if (MAX_READER_NAME < readerNameSize) {
                     // readername byte array was too short
                     readerName = new byte[readerNameSize * CharSize];
@@ -366,7 +366,7 @@ namespace PCSC.Interop.Windows
                     pbAtr,
                     ref atrlen));
             }
-            
+
             pdwProtocol = (IntPtr)proto;
 
             if (rc == SCardError.Success) {
@@ -384,11 +384,11 @@ namespace PCSC.Interop.Windows
                 pdwState = (IntPtr) SCardState.Unknown;
                 szReaderName = null;
             }
-            
+
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardGetStatusChange(
             [In] IntPtr hContext,
             [In] int dwTimeout,
@@ -409,7 +409,7 @@ namespace PCSC.Interop.Windows
                 }
             }
 
-            // On a 64-bit platforms .ToInt32() will throw an OverflowException 
+            // On a 64-bit platforms .ToInt32() will throw an OverflowException
             var timeout = unchecked((int) dwTimeout.ToInt64());
             var rc = SCardHelper.ToSCardError(
                 SCardGetStatusChange(
@@ -431,7 +431,7 @@ namespace PCSC.Interop.Windows
         }
 
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardCancel(
             [In] IntPtr hContext);
 
@@ -439,7 +439,7 @@ namespace PCSC.Interop.Windows
             return SCardHelper.ToSCardError(SCardCancel(hContext));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardGetAttrib(
             [In] IntPtr hCard,
             [In] int dwAttrId,
@@ -447,13 +447,13 @@ namespace PCSC.Interop.Windows
             [In, Out] ref int pcbAttrLen);
 
         public SCardError GetAttrib(IntPtr hCard, IntPtr dwAttrId, byte[] pbAttr, out int pcbAttrLen) {
-            var attrlen = (pbAttr != null) 
+            var attrlen = (pbAttr != null)
                 ? pbAttr.Length
                 : 0;
 
             var rc = SCardHelper.ToSCardError(SCardGetAttrib(
                 hCard,
-                unchecked((int)dwAttrId.ToInt64()), // On a 64-bit platform IntPtr.ToInt32() will throw an OverflowException 
+                unchecked((int)dwAttrId.ToInt64()), // On a 64-bit platform IntPtr.ToInt32() will throw an OverflowException
                 pbAttr,
                 ref attrlen));
 
@@ -461,7 +461,7 @@ namespace PCSC.Interop.Windows
             return rc;
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardSetAttrib(
             [In] IntPtr hCard,
             [In] int dwAttrId,
@@ -469,10 +469,10 @@ namespace PCSC.Interop.Windows
             [In] int cbAttrLen);
 
         public SCardError SetAttrib(IntPtr hCard, IntPtr dwAttrId, byte[] pbAttr, int attrSize) {
-            // On a 64-bit platforms IntPtr.ToInt32() will throw an OverflowException 
+            // On a 64-bit platforms IntPtr.ToInt32() will throw an OverflowException
             var attrid = unchecked((int) dwAttrId.ToInt64());
             var cbAttrLen = 0;
-            
+
             if (pbAttr != null) {
                 if (attrSize > pbAttr.Length || attrSize < 0) {
                     throw new ArgumentOutOfRangeException(nameof(attrSize));
@@ -488,14 +488,14 @@ namespace PCSC.Interop.Windows
                     cbAttrLen));
         }
 
-        [DllImport(WINSCARD_DLL, CharSet = CharSet.Auto)]
+        [DllImport(WINSCARD_DLL, CharSet = CharSet.Unicode)]
         private static extern int SCardFreeMemory(
             [In] IntPtr hContext,
             [In] IntPtr pvMem);
 
         // Windows specific DLL imports
 
-        [DllImport(KERNEL_DLL, CharSet = CharSet.Auto)]
+        [DllImport(KERNEL_DLL, CharSet = CharSet.Unicode)]
         private static extern IntPtr LoadLibrary(string lpFileName);
 
         [DllImport(KERNEL_DLL, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "GetProcAddress")]

--- a/pcsc-sharp/pcsc-standard.csproj
+++ b/pcsc-sharp/pcsc-standard.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Globals">
+    <SccProjectName>SAK</SccProjectName>
+    <SccProvider>SAK</SccProvider>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccLocalPath>SAK</SccLocalPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>PCSC-netStandard</PackageId>
+    <Version>3.8.0.0</Version>
+    <Description>Contains classes to access the Personal Computer/Smart Card Resource Manager using
+the system's native PC/SC API. Implements partial ISO7816 support (APDU etc.).
+The library is written to run on both, Windows and Unix (Linux with Mono using PCSC Lite).</Description>
+    <Product />
+    <Company />
+    <Authors>Daniel Mueller</Authors>
+    <Copyright>Copyright 2017 Daniel Mueller</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseUrl>https://github.com/danm-de/pcsc-sharp/blob/master/COPYING</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/danm-de/pcsc-sharp</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/danm-de/pcsc-sharp/master/pcsc-sharp/pcsc-sharp.png</PackageIconUrl>
+    <PackageTags>PC/SC smartcard apdu pcsc-sharp</PackageTags>
+    <PackageReleaseNotes>Version 3.8.0 recompiled for .NET Standard 2.0</PackageReleaseNotes>
+    <AssemblyName>pcsc-sharp</AssemblyName>
+    <RootNamespace>PCSC</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\Release\netstandard2.0\pcsc-sharp.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\Debug\netstandard2.0\pcsc-sharp.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Basically just one change was necessary to support .NET Standard 2.0:
The `CharSet` had to be changed from `Auto` to `Unicode` as there is no `Auto` in .NET Standard, but according to my research that should be fine for Windows NT or newer.
I first tried to create a .NET Standard 1.4 library, but there some methods (e.g. `GetField` for `SCardHelper.GetAttrDesc<T>`) are missing.

At the moment I set it up to create a new NuGet package with the id "PCSC-netStandard" as I was not sure if the "old" .NET 4.0 package should be "replaced" as 4.0 does not support .NET Standard 2.0. But this can be changed if you think 4.0 support is not needed anymore.

For now I uploaded the generated NuGet package to my private MyGet feed so I can start using it in my UWP project, but if you publish an official package for .NET Standard I will switch to yours.