### PR TITLE
Fix diagnostics log

### DIFF
--- a/Examples/ISO7816-4/Mifare1kTest/MifareCard.cs
+++ b/Examples/ISO7816-4/Mifare1kTest/MifareCard.cs
@@ -23,9 +23,9 @@ namespace Mifare1kTest
                 Data = key
             };
 
-            Debug.WriteLine("Load Authentication Keys: {0}", BitConverter.ToString(loadKeyCmd.ToArray()));
+            Debug.WriteLine($"Load Authentication Keys: {BitConverter.ToString(loadKeyCmd.ToArray())}");
             var response = _isoReader.Transmit(loadKeyCmd);
-            Debug.WriteLine("SW1 SW2 = {0:X2} {1:X2}", response.SW1, response.SW2);
+            Debug.WriteLine($"SW1 SW2 = {response.SW1:X2} {response.SW2:X2}");
 
             return IsSuccess(response);
         }
@@ -47,9 +47,9 @@ namespace Mifare1kTest
                 Data = authBlock.ToArray()
             };
 
-            Debug.WriteLine("General Authenticate: {0}", BitConverter.ToString(authKeyCmd.ToArray()));
+            Debug.WriteLine($"General Authenticate: { BitConverter.ToString(authKeyCmd.ToArray())}");
             var response = _isoReader.Transmit(authKeyCmd);
-            Debug.WriteLine("SW1 SW2 = {0:X2} {1:X2}", response.SW1, response.SW2);
+            Debug.WriteLine($"SW1 SW2 = {response.SW1:X2} {response.SW2:X2}");
 
             return (response.SW1 == 0x90) && (response.SW2 == 0x00);
         }
@@ -64,12 +64,9 @@ namespace Mifare1kTest
                     Le = size
                 };
 
-                Debug.WriteLine("Read Binary (before update): {0}", BitConverter.ToString(readBinaryCmd.ToArray()));
+                Debug.WriteLine($"Read Binary: {BitConverter.ToString(readBinaryCmd.ToArray())}");
                 var response = _isoReader.Transmit(readBinaryCmd);
-                Debug.WriteLine("SW1 SW2 = {0:X2} {1:X2} Data: {2}",
-                    response.SW1,
-                    response.SW2,
-                    BitConverter.ToString(response.GetData()));
+                Debug.WriteLine($"SW1 SW2 = {response.SW1:X2} {response.SW2:X2} Data: {BitConverter.ToString(response.GetData())}");
 
                 return IsSuccess(response)
                     ? response.GetData() ?? new byte[0]
@@ -86,9 +83,9 @@ namespace Mifare1kTest
                 Data = data
             };
 
-            Debug.WriteLine("Update Binary: {0}", BitConverter.ToString(updateBinaryCmd.ToArray()));
+            Debug.WriteLine($"Update Binary: {BitConverter.ToString(updateBinaryCmd.ToArray())}");
             var response = _isoReader.Transmit(updateBinaryCmd);
-            Debug.WriteLine("SW1 SW2 = {0:X2} {1:X2}", response.SW1, response.SW2);
+            Debug.WriteLine($"SW1 SW2 = {response.SW1:X2} {response.SW2:X2}");
 
             return IsSuccess(response);
         }


### PR DESCRIPTION
I noticed a formatting issue on diagnostics messages on mifare sample.

before

![old](https://user-images.githubusercontent.com/7894084/41807298-60b82cd2-76cd-11e8-8bf5-eca43b09dbb9.png)

after

![after](https://user-images.githubusercontent.com/7894084/41807293-56208a1c-76cd-11e8-8b20-f9036ca09c65.png)
