### PR TITLE
Fix converting IntPtr to enum on .NET Core

### DIFF
--- a/src/PCSC/Utils/SCardHelper.cs
+++ b/src/PCSC/Utils/SCardHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -111,7 +111,7 @@ namespace PCSC.Utils
         }
 
         internal static SCardError ToSCardError(IntPtr result) {
-            return (SCardError) result;
+            return (SCardError)(long) result;
         }
 
         internal static SCardError ToSCardError(int result) {
@@ -119,11 +119,11 @@ namespace PCSC.Utils
         }
 
         internal static SCardProtocol ToProto(IntPtr proto) {
-            return (SCardProtocol) proto;
+            return (SCardProtocol)(long) proto;
         }
 
         internal static SCardState ToState(IntPtr state) {
-            return (SCardState) state;
+            return (SCardState)(long) state;
         }
 
         internal static SCRState ToSCRState(long state) {


### PR DESCRIPTION
Closes #77

I'm not 100% sure why this is an issue, but I assume .NET Core really does not like casting 8 Byte IntPtr to 4 byte enum without an intermediate step first.
This shouldn't break any other implementations and fixes the issue for me.