### PR TITLE
The last APDUs data wasn't being added to the response during a multi APDU read operation

### DIFF
--- a/src/PCSC.Iso7816/IsoReader.cs
+++ b/src/PCSC.Iso7816/IsoReader.cs
@@ -299,6 +299,11 @@ namespace PCSC.Iso7816
 
                 // In case there is more data available.
                 le = responseApdu.SW2;
+                if (responseApdu.SW1 == (byte)SW1Code.Normal) {
+                    // add the last ResponseAPDU to the Response object
+                    response.Add(responseApdu);
+                    response.Add(receivePci);
+                }
             } while (
                 // More data available.
                 responseApdu.SW1 == (byte) SW1Code.NormalDataResponse ||


### PR DESCRIPTION
When SW1.Normal is returned indicating no more data to read we add the last received data.