### PR TITLE
dlopen error on Macos Ventura: fixed using .net Core Loading

### DIFF
--- a/src/PCSC/PCSC.csproj
+++ b/src/PCSC/PCSC.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage />
     <PackageLicenseFile>COPYING.txt</PackageLicenseFile>


### PR DESCRIPTION
Hi I recently got a problem using the Nuget Package related to this repo.

upgrading to the last Mac OS Version (Ventura) the dlopen function seems different and no longer works.
I've solved this using library loader from .net Core.

Does anyone know how to solve this keeping the project with the same .net version (netstandard2.0)

however this pull request solves the problem using .net Core 7