### PR TITLE
Set DefaultMaxReceiveSize to 255

### DIFF
--- a/src/PCSC.Iso7816/IsoReader.cs
+++ b/src/PCSC.Iso7816/IsoReader.cs
@@ -9,7 +9,7 @@ namespace PCSC.Iso7816
     /// <summary>A ISO/IEC 7816 compliant reader.</summary>
     public class IsoReader : IIsoReader
     {
-        private const int DefaultMaxReceiveSize = 128;
+        private const int DefaultMaxReceiveSize = 255;
 
         private readonly ISCardContext _context;
         private readonly bool _releaseContextOnDispose;


### PR DESCRIPTION
The latest edition of ISO/IEC 7816 says a GET DATA or GET RESPONSE of length other than 00 will respond with the data and a 90 00 (truncated read).

In previous versions, a GET DATA or GET RESPONSE of length other than 00, but less than the available length would respond with 61 XX, where XX represents the remaining length. The code would continue sending GET RESPONSE commands until all available data was read.

Due to this change in the specification, this library will truncate data by default. Changing the DefaultMaxReceiveSize from 128 to 255 prevents truncation by default.